### PR TITLE
Disabling Google Analytics didn't work

### DIFF
--- a/app/core.py
+++ b/app/core.py
@@ -95,7 +95,11 @@ class BadgeHandler(Handler):
     def get_option(self, name, defval):
         if name not in self.app.config['PARAMETERS']:
             raise KeyError
-        return self.request.get(name, defval)
+        try:
+            val = int(self.request.get(name, defval))
+            return val if val in [0,1] else defval
+        except ValueError:
+            return defval
 
     def calculate_user_values(self, username):
         memcache_data_key = '!data!{}'.format(username)


### PR DESCRIPTION
Disabling Google Analytics didn't work because the variable 'analytics'
in BadgeHandler.get() contained the string '0' when the appropriate GET
parameter was sent. Therefore, '{% if analytics %}' in the template
always evaluated to True and Google Analytics was included.
This change also introduces stricter input validation for the GET
parameters 's' and 'a'.
