### PR TITLE
Use smaller and tailored height values

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@
         <div id="preview">
             <h3>Preview</h3>
             <iframe id="previewFrame" src="/mojombo"
-                    style="border: 0; height: 142px; width: 200px; overflow: hidden;" frameBorder="0"></iframe>
+                    style="border: 0; height: 128px; width: 200px; overflow: hidden;" frameBorder="0"></iframe>
         </div>
     </div>
     <div id="form">
@@ -120,8 +120,8 @@
                 codeArea = gId('code'),
                 lastUser = 'mojombo',
                 loc = document.location,
-                urlTemplate = [loc.protocol, '', loc.host, ':user'].join('/'),
-                codeTemplate = '<iframe src=":url" style="border: 0; height: 142px; width: 200px; overflow: hidden;" frameBorder="0"></iframe>',
+                urlTemplate = [loc.protocol, '', loc.host, '{user}'].join('/'),
+                codeTemplate = '<iframe src="{url}" style="border: 0; height: {height}px; width: 200px; overflow: hidden;" frameBorder="0"></iframe>',
                 previewArea = gId('preview'),
                 spinNewLink = gId('spin-new'),
                 spinner;
@@ -130,7 +130,7 @@
             var username = usernameInput.value;
             if (!username) return;
 
-            var url = urlTemplate.replace(':user', encodeURI(username)),
+            var url = urlTemplate.replace('{user}', encodeURI(username)),
                     options = [];
 
             if (!hackersCheck.checked) {
@@ -146,8 +146,12 @@
             previewFrame.onload = function () {spinner && spinner.stop()};
             previewFrame.setAttribute('src', url);
             
-            codeArea.value = hackersCheck.checked ?
-                                url : codeTemplate.replace(':url', url);
+            if (hackersCheck.checked)
+                codeArea.value = url;
+            else {
+                codeArea.value = codeTemplate.replace('{url}', url)
+                                             .replace('{height}', supportCheck.checked ? '128' : '111')
+            }
             codeArea.style.display = 'block';
             lastUser = usernameInput.value;
         };


### PR DESCRIPTION
Uses a smaller `height` for the `iframe` overall and uses an even
smaller height when support link is disabled. Fixes #71.
